### PR TITLE
Set product_course_id attribute ,resolved issue with course enrolment

### DIFF
--- a/classes/class-dc-woodle-sync.php
+++ b/classes/class-dc-woodle-sync.php
@@ -232,6 +232,7 @@ class DC_Woodle_Sync {
 						}
 						
 						add_post_meta( $post_id, '_course_id', (int) $course['id'] );
+						add_post_meta( $post_id, 'product_course_id', (int) $course['id'] );
 						add_post_meta( $post_id, '_category_id', (int) $course['categoryid'] );
 						add_post_meta( $post_id, '_visibility', $visibility = ( $course['visible'] ) ? 'visible' : 'hidden' );
 						


### PR DESCRIPTION
The enrolment link sent via email doesnt contain id of the moodle course as product_course_id was not set .