### PR TITLE
Fixed PHP Warning:  session_start():

### DIFF
--- a/moowoodle.php
+++ b/moowoodle.php
@@ -55,7 +55,7 @@ require_once trailingslashit( dirname( __FILE__ ) ) . 'includes/class-moowoodle-
 register_activation_hook( __FILE__, array( 'MooWoodle_Install', 'init' ) );
 
 if (!is_admin()) {
-	if ( session_status() == PHP_SESSION_NONE ) {
+	if ( !headers_sent() && session_status() == PHP_SESSION_NONE ) {
 		session_start(
 			array( 'read_and_close' => true )
 		);


### PR DESCRIPTION
I was getting warning while I am working on frontwnd and my debug.log was full of the error: 
`[21-Sep-2022 14:05:26 UTC] PHP Warning:  session_start(): Session cannot be started after headers have already been sent in /var/www/personalwp/public_html/wp-content/plugins/moowoodle/moowoodle.php on line 60` 
Fixed this warning.