### PR TITLE
Fixed PHP Warning: session_start()

### DIFF
--- a/moowoodle.php
+++ b/moowoodle.php
@@ -55,7 +55,7 @@ require_once trailingslashit( dirname( __FILE__ ) ) . 'includes/class-moowoodle-
 register_activation_hook( __FILE__, array( 'MooWoodle_Install', 'init' ) );
 
 if (!is_admin()) {
-	if ( session_status() == PHP_SESSION_NONE ) {
+	if ( !headers_sent() && session_status() == PHP_SESSION_NONE ) {
 		session_start(
 			array( 'read_and_close' => true )
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ This plugin is compatible with the latest version of WooCommerce, that is, Versi
 * Added - Compatibility of Wordpress 6.1.1.
 * Added - Compatibility of WooCommerce 7.4.0.
 * Added - Compatibility of Moodle 4.2.
+* Fix   - PHP Warning: session_start() #50.
 
 = 3.0.3 – 2022-04-12 =
 * Added - Compatibility of Wordpress 5.9.3.


### PR DESCRIPTION
fix: "PHP Warning:  session_start(): Session cannot be started after headers have already been sent "